### PR TITLE
fix memory leak

### DIFF
--- a/src/Event/NexusEvent.lua
+++ b/src/Event/NexusEvent.lua
@@ -76,7 +76,7 @@ function NexusEvent:Connect(Function)
     local BindableEventConnection = self.BindableEvent.Event:Connect(function(UUID)
         --Get the arguments.
         local Arguments = self.LastArguments[UUID]
-        self.LastArgumentsStrong[Arguments] = nil
+        self.LastArgumentsStrong[UUID] = nil
 
         --Fire the event.
         Connection:Fire(table.unpack(Arguments))
@@ -120,7 +120,7 @@ function NexusEvent:Wait()
 
     --Return the arguments.
     local Arguments = self.LastArguments[UUID]
-    self.LastArgumentsStrong[Arguments] = nil
+    self.LastArgumentsStrong[UUID] = nil
     return table.unpack(Arguments)
 end
 


### PR DESCRIPTION
I believe these should be using UUID as the key instead of arguments like they do now